### PR TITLE
Fix scripts directory path

### DIFF
--- a/application/routes/static_files.py
+++ b/application/routes/static_files.py
@@ -5,4 +5,4 @@ static_bp = Blueprint("static_files", __name__)
 
 @static_bp.route("/scripts/<path:filename>")
 def serve_script(filename):
-    return send_from_directory("scripts", filename)
+    return send_from_directory(os.path.join("static", "scripts"), filename)


### PR DESCRIPTION
## Summary
- serve script files from `static/scripts` directory

## Testing
- `pytest -q` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68476ff13568832e8021b824e5637b84