### PR TITLE
Fix index path in service worker

### DIFF
--- a/application/static/scripts/service-worker.js
+++ b/application/static/scripts/service-worker.js
@@ -1,7 +1,7 @@
 const CACHE_NAME = "webcurl-cache-v1";
 const urlsToCache = [
     "/", // Página principal
-    "/template/index.html",
+    "/templates/index.html", // offline fallback page
     "/static/styles/base.css",
     "/static/styles/sidebar.css",
     "/static/styles/editor.css",


### PR DESCRIPTION
## Summary
- update service-worker to cache `/templates/index.html`
- comment the offline fallback page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68476fe5c310832e80979290d5ae3f28