### PR TITLE
Fix service worker cache paths

### DIFF
--- a/application/static/scripts/service-worker.js
+++ b/application/static/scripts/service-worker.js
@@ -1,7 +1,7 @@
 const CACHE_NAME = "webcurl-cache-v1";
 const urlsToCache = [
     "/", // Página principal
-    "/template/index.html",
+    "/templates/index.html",
     "/static/styles/base.css",
     "/static/styles/sidebar.css",
     "/static/styles/editor.css",
@@ -9,7 +9,9 @@ const urlsToCache = [
     "/static/scripts/sidebar.js",
     "/static/scripts/query_manager.js",
     "/static/scripts/protocol.js",
-    "/static/icons/favicon.ico"
+    "/static/favicon.ico",
+    "/static/icon-192x192.png",
+    "/static/icon-512x512.png"
 ];
 
 // Instalar o Service Worker e adicionar ao cache


### PR DESCRIPTION
## Summary
- correct cached paths in PWA service worker

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68476e058e04832ea82fed7ee4e9c51a